### PR TITLE
Support send grid api credentials specification for a specific mail. 

### DIFF
--- a/grails-app/services/uk/co/desirableobjects/sendgrid/SendGridApiConnectorService.groovy
+++ b/grails-app/services/uk/co/desirableobjects/sendgrid/SendGridApiConnectorService.groovy
@@ -52,11 +52,14 @@ class SendGridApiConnectorService {
     
     private List<BodyPart> prepareParameters(SendGridEmail email) {
 
-        checkConfig()
+        checkConfig(email)
 
         List<BodyPart> body = []
-        body << new BodyPart(name: 'api_user', content: grailsApplication.config.sendgrid?.username.bytes)
-        body << new BodyPart(name: 'api_key', content: grailsApplication.config.sendgrid?.password.bytes)
+        if(!email.username)
+            body << new BodyPart(name: 'api_user', content: grailsApplication.config.sendgrid?.username.bytes)
+
+        if(!email.password)
+            body << new BodyPart(name: 'api_key', content: grailsApplication.config.sendgrid?.password.bytes)
 
         email.toMap().each { String key, value ->
             if (value instanceof List<?>) {
@@ -70,8 +73,9 @@ class SendGridApiConnectorService {
 
     }
 
-    private void checkConfig() {
-        if (!grailsApplication.config.sendgrid.password || !grailsApplication.config.sendgrid.username) {
+    private void checkConfig(email) {
+        if ((!grailsApplication.config.sendgrid.password || !grailsApplication.config.sendgrid.username) &&
+            (!email.username || !email.password)) {
             throw new MissingCredentialsException()
         }
     }

--- a/src/groovy/uk/co/desirableobjects/sendgrid/SendGridEmail.groovy
+++ b/src/groovy/uk/co/desirableobjects/sendgrid/SendGridEmail.groovy
@@ -16,12 +16,16 @@ class SendGridEmail {
     String html
     String replyTo
     Date sentDate
+    String username
+    String password
     List<String> bcc = []
     Map headers = [:]
     Map customHandlingInstructions = [:]
     Map<String, File> attachments = [:]
 
     private allParameters = [
+            username: 'api_user',
+            password: 'api_key',
             to:'to',
             from:'from',
             subject:'subject',

--- a/src/groovy/uk/co/desirableobjects/sendgrid/SendGridEmailBuilder.groovy
+++ b/src/groovy/uk/co/desirableobjects/sendgrid/SendGridEmailBuilder.groovy
@@ -10,11 +10,18 @@ class SendGridEmailBuilder {
         this.email = new SendGridEmail()
     }
 
+    SendGridEmailBuilder apiCredentials(String username, String password) {
+        email.username = username
+        email.password = password
+        return this
+    }
+
     SendGridEmailBuilder from(String senderName = null, String sender) {
         email.fromName = senderName
         email.from = sender
         return this
     }
+
 
     SendGridEmailBuilder to(String toName = null, String to) {
         if (toName) {

--- a/test/unit/uk/co/desirableobjects/sendgrid/SendGridApiConnectorServiceSpec.groovy
+++ b/test/unit/uk/co/desirableobjects/sendgrid/SendGridApiConnectorServiceSpec.groovy
@@ -50,7 +50,7 @@ class SendGridApiConnectorServiceSpec extends Specification {
 
     }
     
-    def 'connector provides username and password to api'() {
+    def 'connector provides username and password to api from configuration'() {
 
         given:
             grailsApplication.config.sendgrid = DEFAULT_CREDENTIALS
@@ -68,6 +68,27 @@ class SendGridApiConnectorServiceSpec extends Specification {
         and:
             postData.api_user == USERNAME
             postData.api_key == PASSWORD
+
+    }
+
+    def 'connector provides username and password to api from email'() {
+
+        given:
+            grailsApplication.config = [:]
+
+        and:
+            mockResponse = Mock(Response, constructorArgs: [Mock(HTTPRequest), Mock(HTTPResponse)])
+
+        when:
+            service.post(new SendGridEmail(username: 'testuser', password: 'testpassword'))
+
+        then:
+            1 * mockResponse.contentAsString >> { return "{'status':'ok'}" }
+            0 * _
+
+        and:
+            postData.api_user == 'testuser'
+            postData.api_key == 'testpassword'
 
     }
 

--- a/test/unit/uk/co/desirableobjects/sendgrid/SendGridEmailBuilderSpec.groovy
+++ b/test/unit/uk/co/desirableobjects/sendgrid/SendGridEmailBuilderSpec.groovy
@@ -269,6 +269,21 @@ class SendGridEmailBuilderSpec extends UnitSpec {
             iae.message == 'You cannot use square brackets in attachment filenames'
     }
 
+    def 'Builder can add sendgrid api credentials'() {
+
+        given:
+            SendGridEmailBuilder emailBuilder = createBuilder()
+                                            .withText(DEFAULT_TEXT_CONTENT)
+                                            .apiCredentials('testuser', 'testpassword')
+
+        when:
+            SendGridEmail email = emailBuilder.build()
+
+        then:
+            email.username == 'testuser'
+            email.password == 'testpassword'            
+    }
+
     private File loadFile(String fileName) {
 
         URI uri = getClass().getClassLoader().getResource(fileName).toURI()

--- a/test/unit/uk/co/desirableobjects/sendgrid/SendGridServiceSpec.groovy
+++ b/test/unit/uk/co/desirableobjects/sendgrid/SendGridServiceSpec.groovy
@@ -135,7 +135,32 @@ class SendGridServiceSpec extends Specification {
             } as SendGridEmail)
             0 * _
 
+    }
 
+    def 'Send an email with specific api credentials'() {
+
+        given:
+            service.sendGridApiConnectorService = Mock(SendGridApiConnectorService)
+
+        when:
+            service.sendMail {
+                to this.RECIPIENT
+                from this.SENDER
+                subject this.SUBJECT
+                body this.MESSAGE_TEXT
+                apiCredentials 'testuser', 'testpassword'
+            }
+
+        then:
+            1 * service.sendGridApiConnectorService.post({ SendGridEmail email ->
+                email.to == [RECIPIENT, RECIPIENT2]
+                email.from == SENDER
+                email.subject == SUBJECT
+                email.body == MESSAGE_TEXT
+                email.username == 'testuser'
+                email.password == 'testpassword'
+            } as SendGridEmail)
+            0 * _
 
     }
 


### PR DESCRIPTION
Needed if an application needs to use more than one sendgrid account.